### PR TITLE
Fixing the configuration parameter names

### DIFF
--- a/src/main/java/nl/kpmg/af/service/security/CorsFilter.java
+++ b/src/main/java/nl/kpmg/af/service/security/CorsFilter.java
@@ -34,10 +34,9 @@ public class CorsFilter implements ContainerResponseFilter {
   public void filter(ContainerRequestContext request, ContainerResponseContext response)
       throws IOException {
 
-    if (request.getMethod().equals("OPTIONS")) {
       MultivaluedMap<String, Object> headers = response.getHeaders();
-
-      headers.add("Access-Control-Allow-Origin", "*");
+      String origin = request.getHeaders().getFirst("Origin");
+      headers.add("Access-Control-Allow-Origin", origin);
 
       String requestHeaders = request.getHeaderString("Access-Control-Request-Headers");
       if (requestHeaders != null) {
@@ -49,6 +48,5 @@ public class CorsFilter implements ContainerResponseFilter {
         headers.add("Access-Control-Allow-Methods", requestMethod);
       }
 
-    }
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-ds.service.name=DataService
-ds.service.host=localhost
-ds.service.port=9000
+ds.server.name=DataService
+ds.server.host=localhost
+ds.server.port=9000
 ds.server.securePort=4444
 
 ds.server.security.keystore=${PWD}/config/ssl-keys/server.p12


### PR DESCRIPTION
The default configuration parameter names in `application.properties` are not correct so several parameters defined there (see below) are not correctly parsed and keep their default values.
   * `ds.service.name`
   * `ds.service.host`
   * `ds.service.port` 

This commit fixes it and changes done in `application.properties` file are correctly reflected in the server parameters